### PR TITLE
Fix tests for newer versions of mysql due to typeorm column constraints

### DIFF
--- a/back-end/test/e2e/controllers/util/user/authorization.test.ts
+++ b/back-end/test/e2e/controllers/util/user/authorization.test.ts
@@ -15,7 +15,7 @@ testHubUser.name = "Billy Tester II";
 testHubUser.email = "billyII@testing.com";
 testHubUser.authLevel = AuthLevels.Organizer;
 testHubUser.password = "pbkdf2_sha256$30000$xmAiV8Wihzn5$BBVJrxmsVASkYuOI6XdIZoYLfy386hdMOF8S14WRTi8=";
-testHubUser.team = "The Testers II";
+testHubUser.team = "TheTestersII";
 testHubUser.repo = "tests2.git";
 
 /**

--- a/back-end/test/unit/util/cache/models/collections/usersCacheCollection.test.ts
+++ b/back-end/test/unit/util/cache/models/collections/usersCacheCollection.test.ts
@@ -9,6 +9,7 @@ const testUserInDatabase: User = new User();
 
 testUserInDatabase.name = "Billy Tester";
 testUserInDatabase.email = "billy@testing.com";
+testUserInDatabase.password = "pbkdf2_sha256$30000$xmAiV8Wihzn5$BBVJrxmsVASkYuOI6XdIZoYLfy386hdMOF8S14WRTi8=";
 testUserInDatabase.authLevel = 3;
 testUserInDatabase.team = "The Testers";
 testUserInDatabase.repo = "tests.git";

--- a/back-end/test/unit/util/cache/models/objects/userCached.test.ts
+++ b/back-end/test/unit/util/cache/models/objects/userCached.test.ts
@@ -8,6 +8,7 @@ const testUser: User = new User();
 
 testUser.name = "Billy Tester";
 testUser.email = "billy@testing.com";
+testUser.password = "pbkdf2_sha256$30000$xmAiV8Wihzn5$BBVJrxmsVASkYuOI6XdIZoYLfy386hdMOF8S14WRTi8=";
 testUser.authLevel = 3;
 testUser.team = "The Testers";
 testUser.repo = "tests.git";


### PR DESCRIPTION
Due to some differences in the way that TypeORM seems to interact with newer versions of MySQL. Some of the user cache tests are failing with the cache user tests when adding a user to the database. I fixed it by setting the password on the test user so the insert command was successful. It was also happening with the length of the team code since it is restricted to 13 characters.