### PR TITLE
Fix login form and camera selection  for QR scanner on mobile

### DIFF
--- a/src/public/css/login-style.css
+++ b/src/public/css/login-style.css
@@ -20,3 +20,8 @@
     font-weight: bold;
 }
 
+@media screen and (max-width: 736px) {
+    .w-50 {
+        width: 80% !important;
+    }
+}

--- a/src/public/js/qrInterface.js
+++ b/src/public/js/qrInterface.js
@@ -35,7 +35,7 @@ function startScanner() {
   });
   Instascan.Camera.getCameras().then(function (cameras) {
     if (cameras.length > 0) {
-      camera = cameras[0];
+      camera = cameras[cameras.length - 1];
       scanner.start(camera);
     } else {
       couldNotStartCamera();
@@ -54,7 +54,7 @@ function startCustomScanner(videoObjId, callback) {
   });
   Instascan.Camera.getCameras().then(function (cameras) {
     if (cameras.length > 0) {
-      camera = cameras[0];
+      camera = cameras[cameras.length - 1];
       scanner.start(camera);
     } else {
       couldNotStartCamera();


### PR DESCRIPTION
The login form was not responsive and the QR scanner would use the front-facing camera on mobile.